### PR TITLE
Convert sum benchmark to use `var<mat>`

### DIFF
--- a/benchmark/stan/CMakeLists.txt
+++ b/benchmark/stan/CMakeLists.txt
@@ -26,9 +26,9 @@ function(add_stan_executable name)
         ${PROJECT_SOURCE_DIR}/lib/stan-dev-math
         ${PROJECT_SOURCE_DIR}/lib/stan-dev-math/lib/tbb_2019_U8/include
         ${PROJECT_SOURCE_DIR}/lib/stan-dev-math/lib/boost_1.72.0
-        ${PROJECT_SOURCE_DIR}/lib/stan-dev-math/lib/sundials_5.2.0/include)
+        ${PROJECT_SOURCE_DIR}/lib/stan-dev-math/lib/sundials_5.6.1/include
+        ${PROJECT_SOURCE_DIR}/lib/stan-dev-math/lib/eigen_3.3.9)
     target_link_libraries(${exec}
-        Eigen3::Eigen
         FastAD::FastAD
         ${TBB_LIB}
         ${TBBMALLOC_LIB}

--- a/benchmark/stan/driver.hpp
+++ b/benchmark/stan/driver.hpp
@@ -4,7 +4,7 @@
 
 namespace adb {
 
-template <class F>
+template <class F, class V>
 static void BM_stan(benchmark::State& state)
 {
     F f;
@@ -17,8 +17,16 @@ static void BM_stan(benchmark::State& state)
 
     state.counters["N"] = x.size();
 
+    int i = 0;
     for (auto _ : state) {
-        stan::math::gradient(f, x, fx, grad_fx);
+      V x_var(x);
+      stan::math::var fx_var = f(x_var);
+
+      fx_var.grad();
+      if(i == 0)
+	grad_fx = x_var.adj();
+      stan::math::recover_memory();
+      i++;
     }
 
     // sanity-check that output gradient is good

--- a/benchmark/stan/log_sum_exp.cpp
+++ b/benchmark/stan/log_sum_exp.cpp
@@ -5,14 +5,18 @@ namespace adb {
 
 struct LogSumExpFunc: LogSumExpFuncBase
 {
-    stan::math::var operator()(const Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>& x) const
-    {
-        return stan::math::log_sum_exp(x);
-    }
+  template <typename T>
+  auto operator()(const T& x) const
+  {
+    return stan::math::log_sum_exp(x);
+  }
 };
 
+using varmat = stan::math::var_value<Eigen::VectorXd>;
 using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
-  BENCHMARK_TEMPLATE(BM_stan, LogSumExpFunc, matvar)
-    -> RangeMultiplier(2) -> Range(1, 1 << 14);
+BENCHMARK_TEMPLATE(BM_stan, LogSumExpFunc, matvar)
+  -> RangeMultiplier(2) -> Range(1, 1 << 14);
+BENCHMARK_TEMPLATE(BM_stan, LogSumExpFunc, varmat)
+  -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/benchmark/stan/log_sum_exp.cpp
+++ b/benchmark/stan/log_sum_exp.cpp
@@ -11,7 +11,8 @@ struct LogSumExpFunc: LogSumExpFuncBase
     }
 };
 
-BENCHMARK_TEMPLATE(BM_stan, LogSumExpFunc)
+using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
+  BENCHMARK_TEMPLATE(BM_stan, LogSumExpFunc, matvar)
     -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/benchmark/stan/matrix_product.cpp
+++ b/benchmark/stan/matrix_product.cpp
@@ -15,7 +15,8 @@ struct MatrixProductFunc: MatrixProductFuncBase
     }
 };
 
-BENCHMARK_TEMPLATE(BM_stan, MatrixProductFunc)
+using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
+BENCHMARK_TEMPLATE(BM_stan, MatrixProductFunc, matvar)
     -> RangeMultiplier(2) -> Range(1, 1 << 16);
 
 } // namespace adb

--- a/benchmark/stan/normal_log_pdf.cpp
+++ b/benchmark/stan/normal_log_pdf.cpp
@@ -5,16 +5,20 @@ namespace adb {
 
 struct NormalLogPdfFunc: NormalLogPdfFuncBase
 {
-    auto operator()(const Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>& x) const
-    {
-        stan::math::var mu = mu_;
-        stan::math::var sigma = sigma_;
-        return stan::math::normal_lpdf(x, mu, sigma);
-    }
+  template <typename T>
+  auto operator()(const T& x) const
+  {
+    stan::math::var mu = mu_;
+    stan::math::var sigma = sigma_;
+    return stan::math::normal_lpdf(x, mu, sigma);
+  }
 };
 
+using varmat = stan::math::var_value<Eigen::VectorXd>;
 using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
 BENCHMARK_TEMPLATE(BM_stan, NormalLogPdfFunc, matvar)
+    -> RangeMultiplier(2) -> Range(1, 1 << 14);
+BENCHMARK_TEMPLATE(BM_stan, NormalLogPdfFunc, varmat)
     -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/benchmark/stan/normal_log_pdf.cpp
+++ b/benchmark/stan/normal_log_pdf.cpp
@@ -13,7 +13,8 @@ struct NormalLogPdfFunc: NormalLogPdfFuncBase
     }
 };
 
-BENCHMARK_TEMPLATE(BM_stan, NormalLogPdfFunc)
+using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
+BENCHMARK_TEMPLATE(BM_stan, NormalLogPdfFunc, matvar)
     -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/benchmark/stan/prod.cpp
+++ b/benchmark/stan/prod.cpp
@@ -6,7 +6,8 @@ namespace adb {
 struct ProdFunc: ProdFuncBase
 {};
 
-BENCHMARK_TEMPLATE(BM_stan, ProdFunc)
+using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
+BENCHMARK_TEMPLATE(BM_stan, ProdFunc, matvar)
     -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/benchmark/stan/prod_iter.cpp
+++ b/benchmark/stan/prod_iter.cpp
@@ -6,7 +6,8 @@ namespace adb {
 struct ProdIterFunc: ProdIterFuncBase
 {};
 
-BENCHMARK_TEMPLATE(BM_stan, ProdIterFunc)
-    -> RangeMultiplier(2) -> Range(1, 1 << 14);
+using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
+BENCHMARK_TEMPLATE(BM_stan, ProdIterFunc, matvar)
+  -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/benchmark/stan/prod_iter.cpp
+++ b/benchmark/stan/prod_iter.cpp
@@ -4,10 +4,25 @@
 namespace adb {
 
 struct ProdIterFunc: ProdIterFuncBase
-{};
+{
+  template <class T>
+  stan::math::var operator()(const T& x) const {
+    using namespace stan::math;
 
+    stan::math::var res = 1.0;
+    for(size_t i = 0; i < x.size(); i++) {
+      res *= x.coeffRef(i);
+    }
+
+    return res;
+  }
+};
+
+using varmat = stan::math::var_value<Eigen::VectorXd>;
 using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
 BENCHMARK_TEMPLATE(BM_stan, ProdIterFunc, matvar)
+  -> RangeMultiplier(2) -> Range(1, 1 << 14);
+BENCHMARK_TEMPLATE(BM_stan, ProdIterFunc, varmat)
   -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/benchmark/stan/regression.cpp
+++ b/benchmark/stan/regression.cpp
@@ -20,7 +20,8 @@ struct RegressionFunc: RegressionFuncBase
     }
 };
 
-BENCHMARK_TEMPLATE(BM_stan, RegressionFunc)
+using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
+BENCHMARK_TEMPLATE(BM_stan, RegressionFunc, matvar)
     -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/benchmark/stan/regression.cpp
+++ b/benchmark/stan/regression.cpp
@@ -5,23 +5,26 @@ namespace adb {
 
 struct RegressionFunc: RegressionFuncBase
 {
-    auto operator()(const Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>& x) const
-    {
-        using namespace stan::math;
-        using vec_t = Eigen::Matrix<var, Eigen::Dynamic, 1>;
-        size_t N = (x.size() - 2);
-        Eigen::Map<const vec_t> w(x.data(), N);
-        auto& b = x(N);
-        auto& sigma = x(N + 1);
-        return normal_lpdf(y, multiply(X, w) + b * vec_t::Ones(1000), sigma) +
-                normal_lpdf(w, 0., 1.) +
-                normal_lpdf(b, 0., 1.) -
-                uniform_lpdf(sigma, 0.1, 10.);
-    }
+  template <typename T>
+  auto operator()(const T& x) const
+  {
+    using namespace stan::math;
+    size_t N = (x.size() - 2);
+    const auto& w = x.head(N);
+    const auto& b = x(N);
+    const auto& sigma = x(N + 1);
+    return normal_lpdf(y, add(multiply(X, w), b), sigma) +
+      normal_lpdf(w, 0., 1.) +
+      normal_lpdf(b, 0., 1.) -
+      uniform_lpdf(sigma, 0.1, 10.);
+  }
 };
 
+using varmat = stan::math::var_value<Eigen::VectorXd>;
 using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
 BENCHMARK_TEMPLATE(BM_stan, RegressionFunc, matvar)
+    -> RangeMultiplier(2) -> Range(1, 1 << 14);
+BENCHMARK_TEMPLATE(BM_stan, RegressionFunc, varmat)
     -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/benchmark/stan/stochastic_volatility.cpp
+++ b/benchmark/stan/stochastic_volatility.cpp
@@ -64,7 +64,8 @@ struct StochasticVolatilityFunc: StochasticVolatilityFuncBase
     }
 };
 
-BENCHMARK_TEMPLATE(BM_stan, StochasticVolatilityFunc)
+using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
+  BENCHMARK_TEMPLATE(BM_stan, StochasticVolatilityFunc, matvar)
     -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/benchmark/stan/sum.cpp
+++ b/benchmark/stan/sum.cpp
@@ -5,13 +5,18 @@ namespace adb {
 
 struct SumFunc: SumFuncBase
 {
-    stan::math::var operator()(const Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>& x) const
-    {
-        return stan::math::sum(x);
-    }
+  template <typename T>
+  stan::math::var operator()(const T& x) const
+  {
+    return stan::math::sum(x);
+  }
 };
 
-BENCHMARK_TEMPLATE(BM_stan, SumFunc)
+using varmat = stan::math::var_value<Eigen::VectorXd>;
+using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
+BENCHMARK_TEMPLATE(BM_stan, SumFunc, varmat)
+    -> RangeMultiplier(2) -> Range(1, 1 << 14);
+BENCHMARK_TEMPLATE(BM_stan, SumFunc, matvar)
     -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/benchmark/stan/sum_iter.cpp
+++ b/benchmark/stan/sum_iter.cpp
@@ -6,7 +6,8 @@ namespace adb {
 struct SumIterFunc: SumIterFuncBase
 {};
 
-BENCHMARK_TEMPLATE(BM_stan, SumIterFunc)
+using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
+BENCHMARK_TEMPLATE(BM_stan, SumIterFunc, matvar)
     -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/benchmark/stan/sum_iter.cpp
+++ b/benchmark/stan/sum_iter.cpp
@@ -4,10 +4,25 @@
 namespace adb {
 
 struct SumIterFunc: SumIterFuncBase
-{};
+{
+  template <class T>
+  stan::math::var operator()(const T& x) const {
+    using namespace stan::math;
 
+    stan::math::var res = 0.0;
+    for(size_t i = 0; i < x.size(); i++) {
+      res += x.coeffRef(i);
+    }
+
+    return res;
+  }
+};
+
+using varmat = stan::math::var_value<Eigen::VectorXd>;
 using matvar = Eigen::Matrix<stan::math::var, Eigen::Dynamic, 1>;
 BENCHMARK_TEMPLATE(BM_stan, SumIterFunc, matvar)
+    -> RangeMultiplier(2) -> Range(1, 1 << 14);
+BENCHMARK_TEMPLATE(BM_stan, SumIterFunc, varmat)
     -> RangeMultiplier(2) -> Range(1, 1 << 14);
 
 } // namespace adb

--- a/setup.sh
+++ b/setup.sh
@@ -96,7 +96,7 @@ fi
 
 # setup STAN
 if [ ! -d "$stan" ]; then
-    git clone --depth 1 --branch v3.4.0-rc1 https://github.com/stan-dev/math.git $stan
+    git clone --depth 1 --branch v4.0.0 https://github.com/stan-dev/math.git $stan
     cd $stan
     echo "CXX=g++-10" > make/local
     make -j4 -f make/standalone math-libs

--- a/setup.sh
+++ b/setup.sh
@@ -96,7 +96,7 @@ fi
 
 # setup STAN
 if [ ! -d "$stan" ]; then
-    git clone --depth 1 --branch v3.3.0 https://github.com/stan-dev/math.git $stan
+    git clone --depth 1 --branch v3.4.0-rc1 https://github.com/stan-dev/math.git $stan
     cd $stan
     echo "CXX=g++-10" > make/local
     make -j4 -f make/standalone math-libs


### PR DESCRIPTION
Converted one! As we get the rest of the `var<mat>` stuff in place we can convert the rest.

FastAD sum:
```
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
BM_fastad<SumFunc>/1           6.81 ns         6.81 ns    102241091 N=1
BM_fastad<SumFunc>/2           7.57 ns         7.57 ns     92824386 N=2
BM_fastad<SumFunc>/4           6.88 ns         6.88 ns    101760162 N=4
BM_fastad<SumFunc>/8           7.59 ns         7.59 ns     92351222 N=8
BM_fastad<SumFunc>/16          9.59 ns         9.59 ns     73186002 N=16
BM_fastad<SumFunc>/32          14.0 ns         14.0 ns     49094946 N=32
BM_fastad<SumFunc>/64          27.4 ns         27.3 ns     26011579 N=64
BM_fastad<SumFunc>/128         53.2 ns         53.2 ns     13048065 N=128
BM_fastad<SumFunc>/256         95.4 ns         95.4 ns      7325127 N=256
BM_fastad<SumFunc>/512          179 ns          179 ns      3912272 N=512
BM_fastad<SumFunc>/1024         348 ns          348 ns      2019448 N=1024
BM_fastad<SumFunc>/2048         687 ns          687 ns      1023662 N=2.048k
BM_fastad<SumFunc>/4096        1427 ns         1426 ns       490766 N=4.096k
BM_fastad<SumFunc>/8192        2808 ns         2807 ns       245426 N=8.192k
BM_fastad<SumFunc>/16384       5619 ns         5619 ns       124105 N=16.384k
```

Stan sum:
```
-----------------------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------
BM_stan<SumFunc, varmat>/1           26.8 ns         26.8 ns     26350903 N=1
BM_stan<SumFunc, varmat>/2           31.8 ns         31.8 ns     22029484 N=2
BM_stan<SumFunc, varmat>/4           35.8 ns         35.8 ns     19562051 N=4
BM_stan<SumFunc, varmat>/8           41.0 ns         41.0 ns     16943482 N=8
BM_stan<SumFunc, varmat>/16          45.6 ns         45.6 ns     15352545 N=16
BM_stan<SumFunc, varmat>/32          54.2 ns         54.2 ns     12865175 N=32
BM_stan<SumFunc, varmat>/64          66.4 ns         66.4 ns     10597147 N=64
BM_stan<SumFunc, varmat>/128         95.3 ns         95.3 ns      7351159 N=128
BM_stan<SumFunc, varmat>/256          168 ns          168 ns      4160385 N=256
BM_stan<SumFunc, varmat>/512          281 ns          281 ns      2478569 N=512
BM_stan<SumFunc, varmat>/1024         514 ns          514 ns      1358337 N=1024
BM_stan<SumFunc, varmat>/2048        1127 ns         1127 ns       616329 N=2.048k
BM_stan<SumFunc, varmat>/4096        2041 ns         2040 ns       342880 N=4.096k
BM_stan<SumFunc, varmat>/8192        3947 ns         3946 ns       178015 N=8.192k
BM_stan<SumFunc, varmat>/16384       8133 ns         8132 ns        86724 N=16.384k
BM_stan<SumFunc, matvar>/1           41.8 ns         41.8 ns     16774336 N=1
BM_stan<SumFunc, matvar>/2           43.9 ns         43.9 ns     15897233 N=2
BM_stan<SumFunc, matvar>/4           50.3 ns         50.3 ns     14074020 N=4
BM_stan<SumFunc, matvar>/8           63.8 ns         63.8 ns     10681440 N=8
BM_stan<SumFunc, matvar>/16          90.4 ns         90.4 ns      7792413 N=16
BM_stan<SumFunc, matvar>/32           144 ns          144 ns      5011206 N=32
BM_stan<SumFunc, matvar>/64           341 ns          341 ns      2106592 N=64
BM_stan<SumFunc, matvar>/128          627 ns          627 ns      1089710 N=128
BM_stan<SumFunc, matvar>/256         1252 ns         1252 ns       559918 N=256
BM_stan<SumFunc, matvar>/512         2466 ns         2466 ns       284112 N=512
BM_stan<SumFunc, matvar>/1024        4959 ns         4959 ns       140986 N=1024
BM_stan<SumFunc, matvar>/2048        9966 ns         9965 ns        70066 N=2.048k
BM_stan<SumFunc, matvar>/4096       19909 ns        19907 ns        35190 N=4.096k
BM_stan<SumFunc, matvar>/8192       52597 ns        52590 ns        13336 N=8.192k
BM_stan<SumFunc, matvar>/16384     129659 ns       129640 ns         5416 N=16.384k
```